### PR TITLE
add AudioInfo.StreamDecorator feature

### DIFF
--- a/decorators.go
+++ b/decorators.go
@@ -1,0 +1,26 @@
+package resource
+
+import (
+	"io"
+
+	"github.com/hajimehoshi/ebiten/v2/audio"
+	"github.com/hajimehoshi/ebiten/v2/audio/vorbis"
+)
+
+// LoogOGG wraps OGG vorbis stream into an infinite loop.
+func LoopOGG(stream io.ReadSeeker) io.ReadSeeker {
+	oggStream := stream.(*vorbis.Stream)
+	return audio.NewInfiniteLoop(oggStream, oggStream.Length())
+}
+
+// NopDecorator returns the input stream as is.
+//
+// This is only useful in combination with WAV resources
+// that you don't wan't to eagerly load into memory.
+// Using decorated WAVs can save some memory,
+// but it will be more expensive to play them.
+//
+// See AudioInfo.StreamDecorator field comment to see the full story.
+func NopDecorator(stream io.ReadSeeker) io.ReadSeeker {
+	return stream
+}

--- a/resources.go
+++ b/resources.go
@@ -1,6 +1,8 @@
 package resource
 
 import (
+	"io"
+
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/audio"
 	"golang.org/x/image/font"
@@ -26,6 +28,30 @@ type AudioInfo struct {
 	// This setting accepts values in [-1, 1] range, where -1 mutes the sound
 	// while 1 makes it as loud as possible.
 	Volume float64
+
+	// StreamDecorator is a way to wrap resource stream into another stream
+	// before the associated audio player is created.
+	//
+	// An example usage for this is to wrap OGG stream into an InfiniteLoop stream.
+	// You can use LoopOGG function just for that.
+	// Another example could include a preprocessing stream that would
+	// alter the original resource sound.
+	//
+	// Previously, OGG streams were looped by default.
+	// This option allows a finer control over what to do with a stream.
+	//
+	// A nil decorator will use the original stream as is.
+	//
+	// This function is called exactly once per resource upon its first loading.
+	//
+	// Note: you can use decorators for any type of audio resource (WAV included),
+	// although it's not recommended to do so. By default, this library reads the
+	// entire WAV into memory and creates the raw byte stream player from that.
+	// Unless you really want to do it, leave this field nil for WAVs.
+	// If you want to reduce the application memory footprint, it can be
+	// beneficial to add a NopDecorator decorator that would return the input stream as is.
+	// This will make WAV more expensive to play in terms of CPU clocks.
+	StreamDecorator func(stream io.ReadSeeker) io.ReadSeeker
 }
 
 type Audio struct {


### PR DESCRIPTION
This is a breaking change: OGG will no longer be wrapped in an InfiniteLoop by default. Use StreamDecorator=LoopOGG to get the old behavior.

As for WAVs, it's now possible to disable the in-memory approach this library has (use NopDecorator).
This can be handy for games with tons of WAVs (hundreds or thousands). It's still recommended to keep all SFX in-memory for smaller games and at least keep the most frequent sounds for large games.

This new StreamDecorator feature will be essential to the upkoming custom audio loaders feature.
It also makes it possible to use custom decorators like your own infinite loop implementation, etc.